### PR TITLE
Enable universal

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You could definitely use virtual-dom, virtual-raf, and store-emitter separately 
 ```js
 var extend = require('xtend')
 var vdom = require('virtual-dom')
-var createApp = require('./index')
+var createApp = require('virtual-app')
 var h = vdom.h
 
 /*
@@ -146,7 +146,7 @@ Bind an event to a component. Convenience wrapper around `app.store`.
 **Parameters**
 
 -   `action` **Object** 
--   `action.type` **String** – an identifier for the type of the action
+    -   `action.type` **String** – an identifier for the type of the action
 -   `flag` **String** – call preventDefault on event (default: true)
 
 **Examples**
@@ -193,7 +193,7 @@ Trigger an event that gets passed through the modifier function to change the st
 **Parameters**
 
 -   `action` **Object** 
--   `action.type` **String** – an identifier for the type of the action
+    -   `action.type` **String** – an identifier for the type of the action
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ I keep writing essentially this module with each new project I build that uses v
 
 You could definitely use virtual-dom, virtual-raf, and store-emitter separately (and switch them out for other modules) if this doesn't fit your needs exactly.
 
+## Breaking Changes
+- 3.0.0 : virtual-app no longer appends your app to the dom for you, it returns a dom tree that you can append or turn into an html string
+
 ## Install
 
     npm install --save virtual-app
@@ -23,12 +26,13 @@ You could definitely use virtual-dom, virtual-raf, and store-emitter separately 
 ```js
 var extend = require('xtend')
 var vdom = require('virtual-dom')
-var createApp = require('virtual-app')
+var createApp = require('./index')
+var h = vdom.h
 
 /*
-* create the app passing the container element and virtual-dom
+* create the app passing in virtual-dom
 */
-var app = createApp(document.body, vdom)
+var app = createApp(vdom)
 
 /*
 * The only way to modify state is to trigger an action
@@ -52,9 +56,20 @@ var render = app.start(modifier, {
 
 /*
 * return the tree of your app for rendering
+* this returns a real dom tree that can be appended to your web page
 */
-render(function (state) {
-  return app.h('h1', state.title)
+var domTree = render(function (state) {
+  return h('.app', [
+    h('h1', state.title),
+    h('label', 'Write a new title: '),
+    h('input', {
+      type: 'text',
+      placeholder: state.title,
+      oninput: function (e) {
+        app.store({ type: 'title', title: e.target.value })
+      }
+    })
+  ])
 })
 
 /*
@@ -85,7 +100,15 @@ app.store({
   type: 'title',
   title: 'awesome example'
 })
+
+/*
+* append the dom tree to the page
+*/
+
+document.body.appendChild(domTree)
 ```
+
+see also, example-server.js for a server-side rendering example
 
 ## API
 
@@ -123,7 +146,7 @@ Bind an event to a component. Convenience wrapper around `app.store`.
 **Parameters**
 
 -   `action` **Object** 
-    -   `action.type` **String** – an identifier for the type of the action
+-   `action.type` **String** – an identifier for the type of the action
 -   `flag` **String** – call preventDefault on event (default: true)
 
 **Examples**
@@ -170,7 +193,7 @@ Trigger an event that gets passed through the modifier function to change the st
 **Parameters**
 
 -   `action` **Object** 
-    -   `action.type` **String** – an identifier for the type of the action
+-   `action.type` **String** – an identifier for the type of the action
 
 **Examples**
 
@@ -187,7 +210,6 @@ Create the app.
 
 **Parameters**
 
--   `container` **Object** – DOM element that will act as parent element
 -   `vdom` **Object** – the full virtual-dom module returned by `require('virtual-dom')`
 
 **Examples**
@@ -195,7 +217,7 @@ Create the app.
 ```javascript
 var createVirtualApp = require('virtual-app')
 
-var app = createVirtualApp(document.body, require('virtual-dom'))
+var app = createVirtualApp(require('virtual-dom'))
 ```
 
 ### render
@@ -206,12 +228,15 @@ Render the application. This function is returned by the `app.start()` method.
 
 -   `callback` **Function** – define the virtual tree of your application and return it from this callback
 
+**Returns**
+- **Object** - a dom tree
+
 **Examples**
 
 ```javascript
 var render = app.start(modifier, { food: 'pizza' })
 
-render(function (state) {
+var domTree = render(function (state) {
   return app.h('h1', state.food)
 })
 ```

--- a/example-server.js
+++ b/example-server.js
@@ -1,0 +1,48 @@
+var http = require('http')
+var extend = require('xtend')
+var vdom = require('virtual-dom')
+var createApp = require('./index')
+var h = vdom.h
+
+/*
+* create the app passing the container element and virtual-dom
+*/
+var app = createApp(vdom)
+
+/*
+* The only way to modify state is to trigger an action
+* the modifer function is where you change state based on the type of an action
+*/
+function modifier (action, state) {
+  if (action.type === 'example') {
+    return extend(state, { example: true })
+  } else if (action.type === 'title') {
+    return extend(state, { title: action.title })
+  }
+}
+
+/*
+* Start the application with the modifier function and the initial state as args
+* `app.start()` returns the `render()` function that's used to render your virtual tree
+*/
+var render = app.start(modifier, {
+  example: false,
+  title: 'My web page title'
+})
+
+/*
+* return the tree of your app for rendering
+*/
+var domTree = render(function (state) {
+  return h('.app', [
+    h('h1', state.title)
+  ])
+})
+
+http.createServer(function (request, response) {
+  var htmlPage = domTree.toString()
+  response.writeHead(200, {'Content-Type': 'text/html'})
+  response.end(htmlPage)
+}).listen(8124)
+
+console.log('Server running at http://127.0.0.1:8124/')

--- a/example.js
+++ b/example.js
@@ -4,7 +4,7 @@ var createApp = require('./index')
 var h = vdom.h
 
 /*
-* create the app passing the container element and virtual-dom
+* create the app passing in virtual-dom
 */
 var app = createApp(vdom)
 
@@ -30,6 +30,7 @@ var render = app.start(modifier, {
 
 /*
 * return the tree of your app for rendering
+* this returns a real dom tree that can be appended to your web page
 */
 var domTree = render(function (state) {
   return h('.app', [
@@ -73,5 +74,9 @@ app.store({
   type: 'title',
   title: 'awesome example'
 })
+
+/*
+* append the dom tree to the page
+*/
 
 document.body.appendChild(domTree)

--- a/example.js
+++ b/example.js
@@ -6,7 +6,7 @@ var h = vdom.h
 /*
 * create the app passing the container element and virtual-dom
 */
-var app = createApp(document.body, vdom)
+var app = createApp(vdom)
 
 /*
 * The only way to modify state is to trigger an action
@@ -31,7 +31,7 @@ var render = app.start(modifier, {
 /*
 * return the tree of your app for rendering
 */
-render(function (state) {
+var domTree = render(function (state) {
   return h('.app', [
     h('h1', state.title),
     h('label', 'Write a new title: '),
@@ -73,3 +73,5 @@ app.store({
   type: 'title',
   title: 'awesome example'
 })
+
+document.body.appendChild(domTree)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var loop = require('virtual-raf')
 var createStore = require('store-emitter')
 var assert = require('assert')
+var xtend = require('xtend')
 
 /**
 * Create the app.
@@ -12,12 +13,10 @@ var assert = require('assert')
 *
 * var app = createVirtualApp(document.body, require('virtual-dom'))
 */
-module.exports = function createVirtualApp (container, vdom) {
-  assert.equal(typeof container, 'object', 'container must be an object')
+module.exports = function createVirtualApp (vdom) {
   assert.equal(typeof vdom, 'object', 'vdom must be an object')
 
   var app = {
-    container: container,
     vdom: vdom
   }
 
@@ -66,6 +65,7 @@ module.exports = function createVirtualApp (container, vdom) {
     * Render the application. This function is returned by the `app.start()` method.
     * @name render
     * @param {Function} callback – define the virtual tree of your application and return it from this callback
+    * @return {Object} DOM node tree
     * @example
     * var render = app.start(modifier, { food: 'pizza' })
     *
@@ -74,12 +74,19 @@ module.exports = function createVirtualApp (container, vdom) {
     * })
     */
     return function render (callback) {
-      app.tree = loop(initialState, callback.bind(app), vdom)
-      app.container.appendChild(app.tree.render())
-
-      app.store.on('*', function (action, state) {
-        app.tree.update(state)
-      })
+      var makeRenderFunc = function makeRenderFunc (app) {
+        return function curriedRender (state) {
+          var props = xtend(state, app)
+          return callback(props)
+        }
+      }
+      app.tree = loop(initialState, makeRenderFunc(app), vdom)
+      if (typeof window !== 'undefined') {
+        app.store.on('*', function (action, state) {
+          app.tree.update(state)
+        })
+      }
+      return app.tree.render()
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -74,13 +74,7 @@ module.exports = function createVirtualApp (vdom) {
     * })
     */
     return function render (callback) {
-      var makeRenderFunc = function makeRenderFunc (app) {
-        return function curriedRender (state) {
-          var props = xtend(state, app)
-          return callback(props)
-        }
-      }
-      app.tree = loop(initialState, makeRenderFunc(app), vdom)
+      app.tree = loop(initialState, callback, vdom)
       if (typeof window !== 'undefined') {
         app.store.on('*', function (action, state) {
           app.tree.update(state)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virtual-app",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "A wrapper around [virtual-dom](https://npmjs.com/virtual-dom), [virtual-raf](https://npmjs.com/virtual-raf), & [store-emitter](https://npmjs.com/store-emitter) that provides redux-like, unidirectional state management paired with virtual-dom.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,20 +9,22 @@
     "start": "budo example.js --live"
   },
   "author": "sethvincent <sethvincent@gmail.com>",
+  "contributors": [
+    "benjaminverble <bvrider@gmail.com>",
+    "yoshuawuyts <yoshuawuyts@gmail.com>"
+  ],
   "license": "MIT",
   "dependencies": {
     "store-emitter": "^2.0.0",
     "virtual-dom": "^2.1.1",
-    "virtual-raf": "^3.0.0"
+    "virtual-raf": "^3.0.0",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "budo": "^7.0.2",
     "documentation-readme": "^2.1.1",
-    "global": "^4.3.0",
     "standard": "^5.4.1",
     "tap-spec": "^4.1.1",
-    "tape": "^4.2.2",
-    "xtend": "^4.0.1"
+    "tape": "^4.2.2"
   },
   "repository": {
     "type": "git",
@@ -35,7 +37,8 @@
     "dom",
     "redux",
     "state",
-    "unidirectional"
+    "unidirectional",
+    "universal"
   ],
   "bugs": {
     "url": "https://github.com/sethvincent/virtual-app/issues"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
+    "budo": "^8.0.4",
     "documentation-readme": "^2.1.1",
     "standard": "^5.4.1",
     "tap-spec": "^4.1.1",

--- a/test.js
+++ b/test.js
@@ -1,12 +1,10 @@
 var test = require('tape')
 var vdom = require('virtual-dom')
-var document = require('global/document')
 var createApp = require('./index')
 
 test('create the app', function (t) {
-  var app = createApp(document.body, vdom)
+  var app = createApp(vdom)
   t.ok(app)
-  t.ok(app.container)
   t.ok(app.vdom)
   t.equal(typeof app.h, 'function')
   t.equal(typeof app.on, 'function')
@@ -15,7 +13,7 @@ test('create the app', function (t) {
 })
 
 test('receive an action in the modifier function', function (t) {
-  var app = createApp(document.body, vdom)
+  var app = createApp(vdom)
 
   function modifier (action, state) {
     t.equal(action.type, 'example')
@@ -30,4 +28,20 @@ test('receive an action in the modifier function', function (t) {
     type: 'example',
     example: true
   })
+})
+
+test('render should return dom tree', function (t) {
+  var app = createApp(vdom)
+
+  function modifier (action, state) {
+    // noop
+  }
+
+  var tree = app.start(modifier, {
+    example: false
+  })
+
+  t.ok(typeof tree, 'object')
+  t.ok(typeof tree.firstChild, 'object')
+  t.end()
 })


### PR DESCRIPTION
- there may be some debatable decisions made here. I've extended app onto the initial state so that child components can "dispatch" / call app.store. This is probably not an ideal way to have stateless components (if that is one of the goals). We should probably figure out a pattern or an api that would allow for dispatcher functions to be defined outside of the view/component tree and then extended onto the state object that goes into virtual-raf. 
- I'm not in a hurry to get this merged. I am most excited about participating here as a learning experience and having a conversation about how best to move this "framework" / pattern forward. I think it will be interesting to see how composability and usability are balanced, for instance. 
- Thanks for your time everybody!
